### PR TITLE
Add electionguard dependencies

### DIFF
--- a/packages/electionguard/meta.yaml
+++ b/packages/electionguard/meta.yaml
@@ -1,0 +1,15 @@
+package:
+  name: electionguard
+  version: 1.1.5
+source:
+  sha256: 5e0e19d488e04eb5bc18da04ebd735af7336303f38d12290451ad2448eac645e
+  url: https://files.pythonhosted.org/packages/71/78/0f10dcccec43faa5200100dcab0e45124af0c020e2d0757ea0b518b1f631/electionguard-1.1.5.tar.gz
+patches:
+  - patches/no-gmpy2.patch
+requirements:
+  run:
+    - numpy
+    - hypothesis
+  test:
+  imports:
+  - electionguard

--- a/packages/electionguard/patches/no-gmpy2.patch
+++ b/packages/electionguard/patches/no-gmpy2.patch
@@ -1,0 +1,55 @@
+diff --git a/src/electionguard/group.py b/src/electionguard/group.py
+index 95d8fe5..4baf7ae 100644
+--- a/src/electionguard/group.py
++++ b/src/electionguard/group.py
+@@ -4,7 +4,31 @@
+ 
+ from typing import Any, Final, NamedTuple, Optional, Union
+ from secrets import randbelow
+-from gmpy2 import mpz, powmod, invert, to_binary, from_binary
++#from gmpy2 import mpz, powmod, invert, to_binary, from_binary
++
++def mpz(i: int) -> int:
++  return i
++
++def powmod(a,b,c) -> int:
++  return pow(a,b,c)
++
++def invert(a: int, b: int) -> int:
++    b0 = b
++    x0, x1, y0, y1 = 0, 1, 1, 0
++    while a != 0:
++      (q, a), b = divmod(b, a), a
++      y0, y1 = y1, y0 - q * y1
++      x0, x1 = x1, x0 - q * x1
++
++    if b != 1:
++        raise Exception('gcd(a, b) != 1')
++    return x0 % b0
++
++def to_binary(i: int):
++  return i.to_bytes()
++
++def from_binary(bytes):
++  return i.from_bytes(bytes)
+ 
+ # Constants used by ElectionGuard
+ Q: Final[int] = pow(2, 256) - 189
+@@ -57,7 +81,7 @@ class ElementModQ(NamedTuple):
+         ) and eq_elems(self, other)
+ 
+     def __str__(self) -> str:
+-        return self.elem.digits()
++        return str(self.elem) #.digits()
+ 
+ 
+ class ElementModP(NamedTuple):
+@@ -107,7 +131,7 @@ class ElementModP(NamedTuple):
+         ) and eq_elems(self, other)
+ 
+     def __str__(self) -> str:
+-        return self.elem.digits()
++        return str(self.elem) #.digits()
+ 
+ 
+ # Common constants

--- a/packages/hypothesis/meta.yaml
+++ b/packages/hypothesis/meta.yaml
@@ -1,0 +1,13 @@
+package:
+  name: hypothesis
+  version: 5.36.0
+source:
+  sha256: a473b8428d13a695129e94bf17c43fa6c8a75449ef9121edb32b5ccaf862f16b
+  url: https://files.pythonhosted.org/packages/39/56/41c79c860c2e47efdadc80d98d5645af1c1e87ff907ff5ea945ac827e24b/hypothesis-5.36.0.tar.gz
+requirements:
+  run:
+    - attrs
+    - sortedcontainers
+test:
+  imports:
+  - hypothesis

--- a/packages/sortedcontainers/meta.yaml
+++ b/packages/sortedcontainers/meta.yaml
@@ -1,0 +1,9 @@
+package:
+  name: sortedcontainers
+  version: 2.2.2
+source:
+  sha256: 4e73a757831fc3ca4de2859c422564239a31d8213d09a2a666e375807034d2ba
+  url: https://files.pythonhosted.org/packages/3b/fb/48f6fa11e4953c530b09fa0f2976df5234b0eaabcd158625c3e73535aeb8/sortedcontainers-2.2.2.tar.gz
+test:
+  imports:
+  - sortedcontainers


### PR DESCRIPTION
## ✍️ Description

This is the first PR that adds necessary but unproblematic packages for `electionguard` (it includes `electionguard` itself as well). Although `gmpy2` is not unproblematic, it's included as we added a patch for the necessary code. _This might get changed in the future as it slows down the whole process._ 

## ✅ QA

Before requesting a review, please make sure that:

- [x] Manually check that it's working.
